### PR TITLE
'make test' should not create a coverage file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRC = $(shell find pkg cmd -name "*.go")
 
 .PHONY: test
 test:
-	go test ./pkg/... ./cmd/...
+	go test -cover ./pkg/... ./cmd/...
 
 cover.out: $(SRC)
 	go test ./pkg/... ./cmd/... -coverprofile cover.out

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,14 @@
 export GO111MODULE=on
 export GOPROXY=https://proxy.golang.org
 
+SHELL := /bin/bash -o pipefail
+SRC = $(shell find pkg cmd -name "*.go")
+
 .PHONY: test
 test:
+	go test ./pkg/... ./cmd/...
+
+cover.out: $(SRC)
 	go test ./pkg/... ./cmd/... -coverprofile cover.out
 
 .PHONY: unfork


### PR DESCRIPTION
instead there is now a make command for cover.out specifically