### PR TITLE
Improve output directory naming and placement

### DIFF
--- a/cmd/unfork/cli/home.go
+++ b/cmd/unfork/cli/home.go
@@ -298,7 +298,7 @@ func (h *Home) doUnfork() error {
 
 func (h *Home) findUnforkPath() string {
 	localChart := h.localCharts[h.selectedChartIndex-1]
-	return path.Join(util.HomeDir(), localChart.HelmName)
+	return path.Join(util.HomeDir(), "unfork", localChart.ChartName)
 }
 
 func (h *Home) highlightChart() error {

--- a/pkg/unforker/unfork.go
+++ b/pkg/unforker/unfork.go
@@ -24,7 +24,7 @@ import (
 // returns the directory that was unforked to and an error
 func Unfork(localChart *LocalChart, upstreamChartMatch chartindex.ChartMatch) (string, error) {
 	// write this out to a replicatedhq/kots compatible structure
-	unforkPath := path.Join(util.HomeDir(), localChart.HelmName)
+	unforkPath := path.Join(util.HomeDir(), "unfork", localChart.ChartName)
 	_, err := os.Stat(unforkPath)
 	if !os.IsNotExist(err) {
 


### PR DESCRIPTION
Fixes #17. Fixes #18. Relies on code changes in #19.

Place dirs at `~/unfork/<ChartName>` not `~/<HelmName>` - an example would be `~/unfork/mysql` not `~/intent-lynx`