### PR TITLE
add a command that returns version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,35 @@ export GOPROXY=https://proxy.golang.org
 SHELL := /bin/bash -o pipefail
 SRC = $(shell find pkg cmd -name "*.go")
 
+VERSION_PACKAGE = github.com/replicatedhq/unfork/pkg/version
+VERSION ?=`git describe --tags`
+DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
+GIT_TREE = $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
+ifneq "$(GIT_TREE)" ""
+define GIT_UPDATE_INDEX_CMD
+git update-index --assume-unchanged
+endef
+define GIT_SHA
+`git rev-parse HEAD`
+endef
+else
+define GIT_UPDATE_INDEX_CMD
+echo "Not a git repo, skipping git update-index"
+endef
+define GIT_SHA
+""
+endef
+endif
+
+define LDFLAGS
+-ldflags "\
+	-X ${VERSION_PACKAGE}.version=${VERSION} \
+	-X ${VERSION_PACKAGE}.gitSHA=${GIT_SHA} \
+	-X ${VERSION_PACKAGE}.buildTime=${DATE} \
+"
+endef
+
 .PHONY: test
 test:
 	go test -cover ./pkg/... ./cmd/...
@@ -14,7 +43,7 @@ cover.out: $(SRC)
 
 .PHONY: unfork
 unfork: fmt vet
-	go build -o bin/unfork github.com/replicatedhq/unfork/cmd/unfork
+	go build ${LDFLAGS} -o bin/unfork github.com/replicatedhq/unfork/cmd/unfork
 
 .PHONY: index
 index: unfork

--- a/cmd/unfork/cli/root.go
+++ b/cmd/unfork/cli/root.go
@@ -127,6 +127,7 @@ them off of forks, back to upstream with kustomize patches.`,
 	kubernetesConfigFlags.AddFlags(cmd.Flags())
 
 	cmd.AddCommand(IndexCmd())
+	cmd.AddCommand(VersionCmd())
 
 	_ = viper.BindPFlags(cmd.Flags())
 

--- a/cmd/unfork/cli/version.go
+++ b/cmd/unfork/cli/version.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -15,12 +14,17 @@ func VersionCmd() *cobra.Command {
 		Short: "Print the current version and exit",
 		Long:  `Print the current version and exit`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			build := version.GetBuild()
-			versionInfo, err := json.MarshalIndent(build, "", "    ")
+			// print basic version info
+			fmt.Printf("Replicated Unfork %s\n", version.Version())
+
+			// check if this is the latest release, and display possible upgrade instructions
+			isLatest, latestVer, err := version.IsLatestRelease()
 			if err != nil {
-				return err
+				fmt.Printf("\nUnable to check for newer releases: %s\n", err.Error())
+			} else if !isLatest {
+				fmt.Printf("\nVersion %s is available for unfork. To install updates, run\n  $ curl https://unfork.io/install | bash\n", latestVer)
 			}
-			fmt.Println(string(versionInfo))
+
 			return nil
 		},
 	}

--- a/cmd/unfork/cli/version.go
+++ b/cmd/unfork/cli/version.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/replicatedhq/unfork/pkg/version"
+)
+
+func VersionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the current version and exit",
+		Long:  `Print the current version and exit`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			build := version.GetBuild()
+			versionInfo, err := json.MarshalIndent(build, "", "    ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(versionInfo))
+			return nil
+		},
+	}
+	return cmd
+}

--- a/deploy/.goreleaser.yml
+++ b/deploy/.goreleaser.yml
@@ -18,7 +18,7 @@ builds:
     main: cmd/unfork/main.go
     ldflags: -s -w
       -X github.com/replicatedhq/unfork/pkg/version.version={{.Version}}
-      -X github.com/replicatedhq/unfork/pkg/version.gitSHA={{.Commit}}
+      -X github.com/replicatedhq/unfork/pkg/version.gitSHA={{.FullCommit}}
       -X github.com/replicatedhq/unfork/pkg/version.buildTime={{.Date}}
       -extldflags "-static"
     flags: -tags netgo -installsuffix netgo

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.12
 require (
 	cloud.google.com/go v0.38.0 // indirect
 	github.com/Masterminds/semver v1.4.2
+	github.com/Masterminds/semver/v3 v3.0.1
 	github.com/ahmetalpbalkan/go-cursor v0.0.0-20131010032410-8136607ea412
 	github.com/chzyer/logex v1.1.11-0.20160617073814-96a4d311aa9b // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/gizak/termui/v3 v3.1.0
+	github.com/google/go-github/v28 v28.1.1
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/replicatedhq/kots v0.5.1-0.20190904162055-2988cce69f1c

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RP
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.0.1 h1:2kKm5lb7dKVrt5TYUiAavE6oFc1cFT0057UVGT+JqLk=
+github.com/Masterminds/semver/v3 v3.0.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig v2.20.0+incompatible h1:dJTKKuUkYW3RMFdQFXPU/s6hg10RgctmTjRcbZ98Ap8=
 github.com/Masterminds/sprig v2.20.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -222,6 +224,9 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-github/v28 v28.1.1 h1:kORf5ekX5qwXO2mGzXXOjMe/g6ap8ahVe0sBEulhSxo=
+github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
@@ -418,6 +423,7 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
+github.com/nicksnyder/go-i18n v2.0.2+incompatible h1:Xt6dluut3s2zBUha8/3sj6atWMQbFioi9OMqUGH9khg=
 github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d h1:x3S6kxmy49zXVVyhcnrFqxvNVCBPb2KZ9hV2RBdS840=
 github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=

--- a/pkg/version/build.go
+++ b/pkg/version/build.go
@@ -1,0 +1,7 @@
+package version
+
+// NOTE: these variables are injected at build time
+
+var (
+	version, gitSHA, buildTime string
+)

--- a/pkg/version/run.go
+++ b/pkg/version/run.go
@@ -1,0 +1,12 @@
+package version
+
+import (
+	"time"
+)
+
+var RunAt time.Time
+
+func init() {
+	RunAt = time.Now().UTC()
+	initBuild()
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,8 +1,13 @@
 package version
 
 import (
+	"context"
 	"runtime"
 	"time"
+
+	semver "github.com/Masterminds/semver/v3"
+	"github.com/google/go-github/v28/github"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -69,4 +74,33 @@ func getGoInfo() GoInfo {
 		OS:       runtime.GOOS,
 		Arch:     runtime.GOARCH,
 	}
+}
+
+// IsLatestRelease queries github for the latest release in the project repo. If that release has a semver greater
+// than the current release, it returns false and the new latest release semver. Otherwise, it returns true or error
+func IsLatestRelease() (bool, string, error) {
+	client := github.NewClient(nil)
+	latest, _, err := client.Repositories.GetLatestRelease(context.Background(), "replicatedhq", "unfork")
+	if err != nil {
+		return false, "", errors.Wrap(err, "find latest release")
+	}
+	if latest.GetName() == "" {
+		return false, "", errors.New("latest release name was empty")
+	}
+
+	latestSemver, err := semver.NewVersion(latest.GetName())
+	if err != nil {
+		return false, "", errors.Wrapf(err, "latest release %s does not parse as semver", latest.GetName())
+	}
+
+	currentSemver, err := semver.NewVersion(Version())
+	if err != nil {
+		return false, "", errors.Wrapf(err, "current release %s does not parse as semver", latest.GetName())
+	}
+
+	if currentSemver.LessThan(latestSemver) {
+		return false, latest.GetName(), nil
+	}
+
+	return true, "", nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,72 @@
+package version
+
+import (
+	"runtime"
+	"time"
+)
+
+var (
+	build Build
+)
+
+// Build holds details about this build of the Ship binary
+type Build struct {
+	Version      string     `json:"version,omitempty"`
+	GitSHA       string     `json:"git,omitempty"`
+	BuildTime    time.Time  `json:"buildTime,omitempty"`
+	TimeFallback string     `json:"buildTimeFallback,omitempty"`
+	GoInfo       GoInfo     `json:"go,omitempty"`
+	RunAt        *time.Time `json:"runAt,omitempty"`
+}
+
+type GoInfo struct {
+	Version  string `json:"version,omitempty"`
+	Compiler string `json:"compiler,omitempty"`
+	OS       string `json:"os,omitempty"`
+	Arch     string `json:"arch,omitempty"`
+}
+
+// initBuild sets up the version info from build args
+func initBuild() {
+	build.Version = version
+	if len(gitSHA) >= 7 {
+		build.GitSHA = gitSHA[:7]
+	}
+	var err error
+	build.BuildTime, err = time.Parse(time.RFC3339, buildTime)
+	if err != nil {
+		build.TimeFallback = buildTime
+	}
+
+	build.GoInfo = getGoInfo()
+	build.RunAt = &RunAt
+}
+
+// GetBuild gets the build
+func GetBuild() Build {
+	return build
+}
+
+// Version gets the version
+func Version() string {
+	return build.Version
+}
+
+// GitSHA gets the gitsha
+func GitSHA() string {
+	return build.GitSHA
+}
+
+// BuildTime gets the build time
+func BuildTime() time.Time {
+	return build.BuildTime
+}
+
+func getGoInfo() GoInfo {
+	return GoInfo{
+		Version:  runtime.Version(),
+		Compiler: runtime.Compiler,
+		OS:       runtime.GOOS,
+		Arch:     runtime.GOARCH,
+	}
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,143 @@
+package version
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "empty",
+			want: "",
+		},
+		{
+			name: "version string",
+			want: "v0.1.2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			version = tt.want
+			initBuild()
+
+			got := Version()
+			req.Equal(tt.want, got)
+		})
+	}
+}
+
+func TestGitSHA(t *testing.T) {
+	tests := []struct {
+		name string
+		sha  string
+		want string
+	}{
+		{
+			name: "empty",
+			sha:  "",
+			want: "",
+		},
+		{
+			name: "too short",
+			sha:  "123456",
+			want: "",
+		},
+		{
+			name: "7 chars",
+			sha:  "1234567",
+			want: "1234567",
+		},
+		{
+			name: "full sha",
+			sha:  "e21cf800acca2aa972e7f5f65f7134b5da92f05f",
+			want: "e21cf80",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			gitSHA = tt.sha
+			initBuild()
+
+			got := GitSHA()
+			req.Equal(tt.want, got)
+		})
+	}
+}
+
+func TestBuildTime(t *testing.T) {
+	req := require.New(t)
+	aTime, err := time.Parse(time.RFC3339, "2019-06-26T18:53:19Z")
+	req.NoError(err, "parse constant time")
+
+	tests := []struct {
+		name       string
+		timestring string
+		want       time.Time
+	}{
+		{
+			name:       "empty",
+			timestring: "",
+			want:       time.Time{},
+		},
+		{
+			name:       "proper format",
+			timestring: "2019-06-26T18:53:19Z",
+			want:       aTime,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			buildTime = tt.timestring
+			initBuild()
+
+			got := BuildTime()
+			req.Equal(tt.want, got)
+		})
+	}
+}
+
+func TestGetBuild(t *testing.T) {
+	tests := []struct {
+		name      string
+		gitSHA    string
+		version   string
+		buildTime string
+		want      Build
+	}{
+		{
+			name:   "goInfo",
+			gitSHA: "12345678",
+			want: Build{
+				GitSHA: "1234567",
+				GoInfo: getGoInfo(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			version = tt.version
+			gitSHA = tt.gitSHA
+			buildTime = tt.buildTime
+
+			initBuild()
+
+			got := GetBuild()
+			got.RunAt = nil
+			req.Equal(tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
this is the same command as proposed in https://github.com/replicatedhq/kots/pull/50, and will be modified to incorporate any changes made there.

example output:
```
Replicated Unfork v0.3.0-6-g1ea0c37

Version v0.3.0 is available for unfork. To install updates, run
  $ curl https://unfork.io/install | bash
```

the version will be just vX.Y.Z for actual releases - the suffix is only present for non-tagged builds.